### PR TITLE
컴포넌트 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# API key
+*.env

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,8 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import NavigationBar from './components/NavigationBar';
 import SearchInput from './components/SearchInput';
 import AllResult from './components/results/AllResult';
-
+import NewsResult from './components/results/NewsResult'
+import ImageResult from './components/results/ImageResult';
 function App() {
   return (
     <div className='bg-slate-50 min-h-screen'>
@@ -15,7 +16,9 @@ function App() {
       </div>
       <Routes>
         <Route exact path="/" element={<Navigate to="/all" />} />
-        <Route exact path="/all" element={<AllResult/>}/>
+        <Route exact path="/all" element={<AllResult />} />
+        <Route exact path="/news" element={<NewsResult />} />
+        <Route exact path="/image" element={<ImageResult/>}/>
       </Routes>
       {/* 검색 결과 */}
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,15 @@
 import './App.css';
+import SearchInput from './components/SearchInput';
 
 function App() {
   return (
-    <h1 className='text-3xl font-bold underline '>
-      Hello world!
-    </h1>
+    <div className='bg-slate-50 min-h-screen'>
+      <div className='flex flex-wrap justify-center relative'>
+        <SearchInput/>
+        {/* navigation */}
+      </div>
+      {/* 검색 결과 */}
+    </div>
   );
 }
 

--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,20 @@
 import './App.css';
+import React from 'react';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import NavigationBar from './components/NavigationBar';
 import SearchInput from './components/SearchInput';
 
 function App() {
   return (
     <div className='bg-slate-50 min-h-screen'>
       <div className='flex flex-wrap justify-center relative'>
-        <SearchInput/>
+        <SearchInput />
+        <NavigationBar/>
         {/* navigation */}
       </div>
+      <Routes>
+        <Route exact path="/" element={<Navigate to="/all"/>}/>
+      </Routes>
       {/* 검색 결과 */}
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import NavigationBar from './components/NavigationBar';
 import SearchInput from './components/SearchInput';
+import AllResult from './components/results/AllResult';
 
 function App() {
   return (
@@ -13,7 +14,8 @@ function App() {
         {/* navigation */}
       </div>
       <Routes>
-        <Route exact path="/" element={<Navigate to="/all"/>}/>
+        <Route exact path="/" element={<Navigate to="/all" />} />
+        <Route exact path="/all" element={<AllResult/>}/>
       </Routes>
       {/* 검색 결과 */}
     </div>

--- a/src/components/NavigationBar.jsx
+++ b/src/components/NavigationBar.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import {NavLink, useLocation} from 'react-router-dom'
+
+function NavigationBar() {
+    const { search } = useLocation();
+  return (
+    <div className="flex justify-center items-center mt-10 w-full border-2 h-16 border-t-green-500">
+      <NavLink to={`/all${search}`} className={({isActive}) => (isActive ? 'text-green-500 m-20' : 'm-20')}>
+        통합
+      </NavLink>
+      <NavLink to={`/news${search}`} className={({isActive}) => (isActive ? 'text-green-500 m-20' : 'm-20')}>
+        뉴스
+      </NavLink>
+      <NavLink to={`/image${search}`} className={({isActive}) => (isActive ? 'text-green-500 m-20' : 'm-20')}>
+        이미지
+      </NavLink>
+    </div>
+  );
+}
+
+export default NavigationBar

--- a/src/components/SearchInput.jsx
+++ b/src/components/SearchInput.jsx
@@ -1,0 +1,34 @@
+import React, {useState, useEffect,useCallback} from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+
+function SearchInput() {
+  const [searchText, setSearchText] = useState('');
+  const [searchParams, setSearchParams] = useSearchParams();
+
+    useEffect(() => {
+      setSearchText(searchParams.get('q')??"")
+  },[searchParams]);
+  const onChangeInput = useCallback((e) => {
+    setSearchText(e.target.value);
+  },[]);
+  const onKeyUp = useCallback((e) => {
+    if (e.key === 'Enter' && e.target.value.trim().length > 0) {
+      setSearchParams({q: e.target.value});
+    }
+  },[setSearchParams]);
+
+  return (
+    <input
+      value={searchText}
+      type="text"
+      className="w-96 h-11 bg-slate-50 border outline-none p-6 text-black mt-10 shadow-md hover:shadow-lg "
+      placeholder="검색어를 입력하세요"
+      onChange={onChangeInput}
+      onKeyUp={onKeyUp}
+      />
+      
+  );
+}
+
+export default SearchInput;

--- a/src/components/results/AllResult.jsx
+++ b/src/components/results/AllResult.jsx
@@ -1,0 +1,110 @@
+import axios from 'axios';
+import React, {useEffect, useState, useCallback} from 'react';
+import {useQuery} from 'react-query';
+import {useLocation} from 'react-router-dom';
+import SearchTermRequired from './SearchTermRequired';
+import {Oval} from 'react-loader-spinner';
+import NoResult from './NoResult';
+import ReactPaginate from 'react-paginate';
+
+function AllResult() {
+  const location = useLocation();
+  const search = new URLSearchParams(location.search).get('q');
+    const itemsPerPage = 10;
+    const BingSearchapiKey = process.env.REACT_APP_BING_SEARCH_API_KEY;
+  const [currentItems, setCurrentItems] = useState([]);
+  const [pageCount, setPageCount] = useState(0);
+  const [itemOffset, setItemOffset] = useState(0);
+  const {data, isLoading} = useQuery(
+    ['allResult', search],
+    () =>
+      axios
+        .get(`https://bing-web-search1.p.rapidapi.com/search`, {
+          headers: {
+            'X-BingApis-SDK': 'true',
+                'X-RapidAPI-Key': `${BingSearchapiKey}`,
+            'X-RapidAPI-Host': 'bing-web-search1.p.rapidapi.com',
+          },
+          params: {
+            q: search,
+            setLang: 'ko',
+            safeSearch: 'Off',
+            freshness: 'Day',
+            count: '50',
+          },
+        })
+        .then((data) => data?.data),
+    {
+      refetchOnWindowFocus: false,
+      enabled: !!search,
+      cacheTime: 0,
+    },
+  );
+
+  useEffect(() => {
+    const endOffset = itemOffset + itemsPerPage;
+    setCurrentItems(data?.webPages?.value.slice(itemOffset, endOffset));
+    setPageCount(Math.ceil((data?.webPages?.value.length ?? 0) / itemsPerPage));
+  }, [data?.webPages, itemOffset]);
+
+  const handlePageClick = useCallback(
+      (e) => {
+          console.log(e.selected)
+      setItemOffset((e.selected * itemsPerPage) % data?.webPages?.value.length);
+    },
+    [data?.webPages?.value.length],
+  );
+  if (!search) return <SearchTermRequired />;
+  if (isLoading)
+    return (
+      <Oval
+        height={100}
+        width={100}
+        color="#4fa94d"
+        wrapperStyle={{}}
+        wrapperClass="flex justify-center mt-52"
+        visible={true}
+        ariaLabel="loading-indicator"
+        secondaryColor="#ffffff"
+        strokeWidth={5}
+        strokeWidthSecondary={2}
+      />
+    );
+  return (
+    <>
+      <div className="flex flex-col justify-center align-middle m-auto w-[700px]">
+        {data?.webPages.value.length > 0 ? (
+          currentItems?.map(({url, name, snippet}, index) => (
+            <div key={index} className="mt-10">
+              <a href={url} target="_blank" rel="noreferrer">
+                <p className="text-sm">{url.length > 40 ? url.substring(0, 40) : url}</p>
+                <p className="text-lg text-blue-700 hover:underline">{name}</p>
+                <p className="text-xs">{snippet}</p>
+              </a>
+            </div>
+          ))
+        ) : (
+          <NoResult />
+        )}
+      </div>
+      <ReactPaginate
+        breakLabel="..."
+        nextLabel=">>"
+        previosLabel="<<"
+        pageRangeDisplayed={10}
+        pageLinkClassName="-ml-[1] text-[#22C55E] bg-slate-50 block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        previousLinkClassName="text-[#22C55E] bg-slate-50 block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        breakLinkClassName="-ml-[1] text-[#22C55E] bg-slate-50 block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        nextLinkClassName="-ml-[1] text-[#22C55E] bg-slate-50 block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        containerClassName="flex ml-auto mr-auto w-fit mt-10 pb-10 select-none"
+        activeLinkClassName="z-[3]  text-slate-50 bg-[#22C55E] block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        disabledLinkClassName="text-[#6c757d] pointer-events-none bg-slate-50 border-[#dee2e6] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        renderOnZeroPageCount={null}
+        onPageChange={handlePageClick}
+        pageCount={pageCount}
+      />
+    </>
+  );
+}
+
+export default AllResult;

--- a/src/components/results/ImageResult.jsx
+++ b/src/components/results/ImageResult.jsx
@@ -1,0 +1,102 @@
+import axios from 'axios';
+import React, {useEffect, useState, useCallback} from 'react';
+import {useQuery} from 'react-query';
+import {useLocation} from 'react-router-dom';
+import SearchTermRequired from './SearchTermRequired';
+import {Oval} from 'react-loader-spinner';
+import NoResult from './NoResult';
+import ReactPaginate from 'react-paginate';
+
+function NewsResult() {
+  const location = useLocation();
+  const search = new URLSearchParams(location.search).get('q');
+  const itemsPerPage = 10;
+  const BingSearchapiKey = process.env.REACT_APP_BING_SEARCH_API_KEY;
+  const [currentItems, setCurrentItems] = useState([]);
+  const [pageCount, setPageCount] = useState(0);
+  const [itemOffset, setItemOffset] = useState(0);
+  const {data, isLoading} = useQuery(
+    ['newsResult', search],
+    () =>
+      axios
+        .get(`https://image-search10.p.rapidapi.com/index.php`, {
+          headers: {
+            'X-RapidAPI-Key': `${BingSearchapiKey}`,
+            'X-RapidAPI-Host': 'image-search10.p.rapidapi.com',
+          },
+          params: {
+            q: search,
+          },
+        })
+        .then((data) => data?.data),
+    {
+      refetchOnWindowFocus: false,
+      enabled: !!search,
+      cacheTime: 0,
+    },
+  );
+
+  useEffect(() => {
+    const endOffset = itemOffset + itemsPerPage;
+    setCurrentItems(data?.data.slice(itemOffset, endOffset));
+    setPageCount(Math.ceil((data?.data.length ?? 0) / itemsPerPage));
+  }, [data?.data,itemOffset]);
+
+  const handlePageClick = useCallback(
+    (e) => {
+      console.log(e.selected);
+      setItemOffset((e.selected * itemsPerPage) % data?.data.length);
+    },
+    [data?.data.length],
+  );
+  if (!search) return <SearchTermRequired />;
+  if (isLoading)
+    return (
+      <Oval
+        height={100}
+        width={100}
+        color="#4fa94d"
+        wrapperStyle={{}}
+        wrapperClass="flex justify-center mt-52"
+        visible={true}
+        ariaLabel="loading-indicator"
+        secondaryColor="#ffffff"
+        strokeWidth={5}
+        strokeWidthSecondary={2}
+      />
+    );
+  return (
+    <>
+      <div className="flex justify-center items-center flex-wrap m-auto w-[900px]">
+        {data?.data.length > 0 ? (
+          currentItems?.map(({title, content_url, image}, index) => (
+            <a href={content_url} target="blank" rel="noreferrer" className="p-3 w-48 h-48">
+              <img src={image} alt={title} loading="lazy" className="hover:shadow-xl" />
+              <p className="w-36 break-words text-sm mt-3 hover:underline">{title.substring(0, 10)}...</p>
+            </a>
+          ))
+        ) : (
+          <NoResult />
+        )}
+      </div>
+      <ReactPaginate
+        breakLabel="..."
+        nextLabel=">>"
+        previosLabel="<<"
+        pageRangeDisplayed={10}
+        pageLinkClassName="-ml-[1] text-[#22C55E] bg-slate-50 block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        previousLinkClassName="text-[#22C55E] bg-slate-50 block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        breakLinkClassName="-ml-[1] text-[#22C55E] bg-slate-50 block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        nextLinkClassName="-ml-[1] text-[#22C55E] bg-slate-50 block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        containerClassName="flex ml-auto mr-auto w-fit mt-10 pb-10 select-none"
+        activeLinkClassName="z-[3]  text-slate-50 bg-[#22C55E] block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        disabledLinkClassName="text-[#6c757d] pointer-events-none bg-slate-50 border-[#dee2e6] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        renderOnZeroPageCount={null}
+        onPageChange={handlePageClick}
+        pageCount={pageCount}
+      />
+    </>
+  );
+}
+
+export default NewsResult;

--- a/src/components/results/NewsResult.jsx
+++ b/src/components/results/NewsResult.jsx
@@ -1,0 +1,111 @@
+import axios from 'axios';
+import React, {useEffect, useState, useCallback} from 'react';
+import {useQuery} from 'react-query';
+import {useLocation} from 'react-router-dom';
+import SearchTermRequired from './SearchTermRequired';
+import {Oval} from 'react-loader-spinner';
+import NoResult from './NoResult';
+import ReactPaginate from 'react-paginate';
+
+function NewsResult() {
+  const location = useLocation();
+  const search = new URLSearchParams(location.search).get('q');
+    const itemsPerPage = 10;
+    const BingSearchapiKey = process.env.REACT_APP_BING_SEARCH_API_KEY;
+  const [currentItems, setCurrentItems] = useState([]);
+  const [pageCount, setPageCount] = useState(0);
+  const [itemOffset, setItemOffset] = useState(0);
+  const {data, isLoading} = useQuery(
+    ['newsResult', search],
+    () =>
+      axios
+        .get(`https://bing-web-search1.p.rapidapi.com/search`, {
+          headers: {
+            'X-BingApis-SDK': 'true',
+            'X-RapidAPI-Key': `${BingSearchapiKey}`,
+            'X-RapidAPI-Host': 'bing-web-search1.p.rapidapi.com',
+          },
+          params: {
+            q: search,
+            'responseFilter[0]': 'News',
+            setLang: 'ko',
+            safeSearch: 'Off',
+            freshness: 'Week',
+            count: '50',
+          },
+        })
+        .then((data) => data?.data),
+    {
+      refetchOnWindowFocus: false,
+      enabled: !!search,
+      cacheTime: 0,
+    },
+  );
+
+  useEffect(() => {
+    const endOffset = itemOffset + itemsPerPage;
+    setCurrentItems(data?.webPages?.value.slice(itemOffset, endOffset));
+    setPageCount(Math.ceil((data?.webPages?.value.length ?? 0) / itemsPerPage));
+  }, [data?.webPages, itemOffset]);
+
+  const handlePageClick = useCallback(
+      (e) => {
+          console.log(e.selected)
+      setItemOffset((e.selected * itemsPerPage) % data?.webPages?.value.length);
+    },
+    [data?.webPages?.value.length],
+  );
+  if (!search) return <SearchTermRequired />;
+  if (isLoading)
+    return (
+      <Oval
+        height={100}
+        width={100}
+        color="#4fa94d"
+        wrapperStyle={{}}
+        wrapperClass="flex justify-center mt-52"
+        visible={true}
+        ariaLabel="loading-indicator"
+        secondaryColor="#ffffff"
+        strokeWidth={5}
+        strokeWidthSecondary={2}
+      />
+    );
+  return (
+    <>
+      <div className="flex flex-col justify-between flex-wrap m-auto items-start w-[700px]">
+        {data?.webPages.value.length > 0 ? (
+          currentItems?.map(({url, name, snippet, dateLastCrawled}, index) => (
+            <div key={index} className="mt-10 border-2 rounded-lg p-8 w-[700px]">
+              <a href={url} target="_blank" rel="noreferrer" className="hover:underline">
+                <p className="text-lg text-blue-700">{name}</p>
+              </a>
+              <p className="text-xs">{snippet}</p>
+              <p className="text-xs mt-5">{dateLastCrawled.substring(0, 10)}</p>
+            </div>
+          ))
+        ) : (
+          <NoResult />
+        )}
+      </div>
+      <ReactPaginate
+        breakLabel="..."
+        nextLabel=">>"
+        previosLabel="<<"
+        pageRangeDisplayed={10}
+        pageLinkClassName="-ml-[1] text-[#22C55E] bg-slate-50 block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        previousLinkClassName="text-[#22C55E] bg-slate-50 block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        breakLinkClassName="-ml-[1] text-[#22C55E] bg-slate-50 block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        nextLinkClassName="-ml-[1] text-[#22C55E] bg-slate-50 block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        containerClassName="flex ml-auto mr-auto w-fit mt-10 pb-10 select-none"
+        activeLinkClassName="z-[3]  text-slate-50 bg-[#22C55E] block border solid border border-[#dee2e6] px-[0.75rem] py-[0.375rem] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        disabledLinkClassName="text-[#6c757d] pointer-events-none bg-slate-50 border-[#dee2e6] hover:z-[2] hover:text-[#22C55E] hover:bg-[#e9ecef] hover:border=[#dee2e6]"
+        renderOnZeroPageCount={null}
+        onPageChange={handlePageClick}
+        pageCount={pageCount}
+      />
+    </>
+  );
+}
+
+export default NewsResult;

--- a/src/components/results/NoResult.jsx
+++ b/src/components/results/NoResult.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function NoResult() {
+  return (
+    <div className="flex justify-center items-center m-auto h-96">
+      <p className="text-3xl text-black">검색 결과가 존재하지 않습니다.</p>
+    </div>
+  );
+}
+
+export default NoResult;

--- a/src/components/results/SearchTermRequired.jsx
+++ b/src/components/results/SearchTermRequired.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function SearchTermRequired() {
+  return (
+    <div className="flex justify-center items-center m-auto h-96">
+      <p className="text-3xl text-gray-400">검색어를 입력하세요.</p>
+    </div>
+  );
+}
+
+export default SearchTermRequired;

--- a/src/index.js
+++ b/src/index.js
@@ -2,14 +2,18 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
-import {BrowserRouter} from 'react-router-dom'
+import {BrowserRouter} from 'react-router-dom';
+import {QueryClientProvider, QueryClient} from 'react-query';
+
+const queryClient = new QueryClient();
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
   </React.StrictMode>,
 );
-

--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App';
+import {BrowserRouter} from 'react-router-dom'
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
-  </React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>,
 );
 


### PR DESCRIPTION
# 검색 input 컴포넌트 구현

검색어를 입력하고 enter를 하면 url에 `q=검색어` 로 표시되게 구현함

*  `useSearchParams`를 사용해서 입력한 검색어를 쿼리에 추가함

* `tailwindcss`를 사용해서 input의 디자인을 구현함
https://tailwindcss.com/docs/hover-focus-and-other-states#disabled

# 네비게이션 바 구현

검색 결과를 항목으로 나누어서 사용자에게 보여줄수 있게 네비게이션 바를 구현함

* `NavLink`를 사용해서 `isActive`여부에 따라 텍스트의 색이 변경되게 해서 어느 항목의 검색 결과를 보여주는지를 알기 쉽게 설정함

* `App`에다가 `Routes`를 작성해서 `/`경로로 들어가도 초기 상태에는 무조건 `/all`로 리다이렉트하게 설정함으로써, 다른 항목을 선택하지 않은 경우에는 항상 통합 검색 값을 표시하게 설정함

# 통합 검색 결과 구현
 원래 계획은 google search API를 사용하여 구현하려고 했으나 API가 사라져서 대신 Bing search API를 사용함

https://rapidapi.com/microsoft-azure-org-microsoft-cognitive-services/api/bing-web-search1

* API 키 값은 환경변수로 따로 선언하여 보안상 보이지 않게 작업함 ( 만약 누군가가 이걸 사용한다면 API 키 값은 따로 본인이 얻어서 작성할 것!)

* `SearchInput`컴포넌트에서 입력한 값을 쿼리로 추가하고  해당 쿼리 값을 통해서 API의 GET메소드를 호출하여 받은 데이터들을 반복적으로 렌더링함

* `react-query`에서 `useQuery`를 사용하여 `isLoading`이 참일 경우에 `react-loader-spinner`에서 가져온 `Oval`이 나타나게 설정함

* `react-paginate`를 사용해서 10개의 데이터만 나타나게 하고 밑에 페이지를 선택하는 컴포넌트를 제작함(`itemsPerPage`의 값을 10으로 지정함)

* 만약 검색어가 입력되지 않은 경우에는 `SearchTermRequired`컴포넌트가 렌더링 되고, 결과값이 존재하지 않을때는 `NoResult`값이 렌더링 됨

* 페이지네이션의 디자인은 `tailwindcss`를 사용하여 설정함

# 뉴스 검색 결과 구현

통합 검색 결과 구현에서 사용한 API와 동일하며 
`params`에  'responseFilter[0]': 'News'를 추가하여 뉴스만 나타나게 설정함

# 이미지 검색 결과 구현

bing image search  api를 사용하려 했으나 api키가 인식되지 않아서 다른 `image search api를 사용하기로 했음

https://rapidapi.com/image-search-image-search-default/api/image-search10

* 가져온 데이터의 길이만큼 렌더링 되며 이미지를 클릭하면 이미지의 출처 사이트로 이동함

* 마우스를 올리면 그림자가 생성되게 함



